### PR TITLE
Add the main page, including task components.

### DIFF
--- a/front-end/src/Home.css
+++ b/front-end/src/Home.css
@@ -1,0 +1,3 @@
+.task-list {
+    padding: "16px";
+}

--- a/front-end/src/Home.js
+++ b/front-end/src/Home.js
@@ -1,21 +1,39 @@
-import { Link } from 'react-router-dom'
 import './Home.css'
+import React, { useState } from 'react'
+import Task from './Task'
+import TaskFilterBar from './TaskFilterBar'
 
-/**
- * A React component that represents the Home page of the app.
- * @param {*} param0 an object holding any props passed to this component from its parent component
- * @returns The contents of this component, in JSX form.
- */
 const Home = props => {
-  return (
-    <>
-      <h1>Hello and welcome!</h1>
-      <p>This is a full MERN-stack app, whether you like it or not!</p>
-      <p>
-        Check out the <Link to="/menu">menu page</Link>.
-      </p>
-    </>
-  )
+    const dummyTasks = [
+        { id: 1, title: 'Task 1', dueDate: '2023-03-05', status: 'NOT_STARTED' },
+        { id: 2, title: 'Task 2', dueDate: '2023-03-06', status: 'IN_PROGRESS' },
+        { id: 3, title: 'Task 3', dueDate: '2023-03-07', status: 'COMPLETED' },
+        { id: 4, title: 'Task 4', dueDate: '2023-03-08', status: 'NOT_STARTED' },
+        { id: 5, title: 'Task 5', dueDate: '2023-03-09', status: 'IN_PROGRESS' },
+        { id: 6, title: 'Task 6', dueDate: '2023-03-10', status: 'COMPLETED' },
+        { id: 7, title: 'Task 7', dueDate: '2023-03-11', status: 'NOT_STARTED' },
+        { id: 8, title: 'Task 8', dueDate: '2023-03-12', status: 'IN_PROGRESS' },
+        { id: 9, title: 'Task 9', dueDate: '2023-03-13', status: 'COMPLETED' },
+        { id: 10, title: 'Task 10', dueDate: '2023-03-14', status: 'NOT_STARTED' },
+    ]
+
+    const [tasks] = useState(dummyTasks)
+    const [statusFilter, setStatusFilter] = useState("NOT_STARTED")
+    const filteredTasks = tasks.filter(task => task.status === statusFilter)
+
+    return (
+        <div>
+            <div class="task-list">
+                {filteredTasks.map((task, idx) => (
+                    <React.Fragment key={idx}>
+                        <Task key={task.id} task={task} />
+                        {idx < filteredTasks.length-1 && <hr class="task-separator" />}
+                    </React.Fragment>
+                ))}
+            </div>
+            <TaskFilterBar statusFilter={statusFilter} setStatusFilter={setStatusFilter} />
+        </div>
+    )
 }
 
 // make this component available to be imported into any other file

--- a/front-end/src/Task.css
+++ b/front-end/src/Task.css
@@ -1,0 +1,33 @@
+.task-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px;
+}
+  
+.task-info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+  
+.task-title {
+    font-size: 20px;
+    font-weight: bold;
+}
+  
+.task-due-date {
+    font-size: 16px;
+    color: gray;
+}
+  
+.task-checkbox {
+    display: flex;
+    align-items: center;
+}
+
+.task-checkbox-input {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+}

--- a/front-end/src/Task.js
+++ b/front-end/src/Task.js
@@ -1,0 +1,19 @@
+import "./Task.css"
+
+const Task = props => {
+    const { title, dueDate, status } = props.task
+
+    return (
+        <div class="task-container">
+            <div class="task-info">
+                <div class="task-title">{title}</div>
+                <div class="task-due-date">{dueDate}</div>
+            </div>
+            <div class="task-checkbox">
+                <input type="checkbox" class="task-checkbox-input" checked={status === "COMPLETED"} />
+            </div>
+        </div>
+    )
+}
+
+export default Task

--- a/front-end/src/TaskFilterBar.css
+++ b/front-end/src/TaskFilterBar.css
@@ -1,0 +1,26 @@
+.task-filter-bar {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 50px;
+    background-color: #f1f1f1;
+    border-top: 1px solid #ccc;
+}
+
+.task-filter-button {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 18px;
+    font-weight: bold;
+    color: #777;
+    cursor: pointer;
+}
+
+.task-filter-button.active {
+    color: #000;
+    background-color: #ddd;
+}

--- a/front-end/src/TaskFilterBar.js
+++ b/front-end/src/TaskFilterBar.js
@@ -1,0 +1,32 @@
+import './TaskFilterBar.css'
+
+const TaskFilterBar = props => {
+    const { statusFilter, setStatusFilter } = props
+
+    const checkStatusFilter = status => status === statusFilter ? "active" : ""
+  
+    return (
+        <div class="task-filter-bar">
+            <div
+                class={`task-filter-button ${checkStatusFilter("NOT_STARTED")}`}
+                onClick={() => setStatusFilter("NOT_STARTED")}
+            >
+                Not Started
+            </div>
+            <div
+                class={`task-filter-button ${checkStatusFilter("IN_PROGRESS")}`}
+                onClick={() => setStatusFilter("IN_PROGRESS")}
+            >
+                In Progress
+            </div>
+            <div
+                class={`task-filter-button ${checkStatusFilter("COMPLETED")}`}
+                onClick={() => setStatusFilter("COMPLETED")}
+            >
+                Completed
+            </div>
+        </div>
+    )
+}
+
+export default TaskFilterBar


### PR DESCRIPTION
This PR adds the main page of the app along with the task components and the task filter switch bar at the bottom of the page. For now, 10 dummy tasks are loaded in JSON form, but once we have our backend/database up and running it will be very easy to substitute these dummy tasks with tasks loaded from another source.

Some possible changes that could be made in the future: styling the checkboxes so that they better fit in with the rest of the app (right now the browser default checkbox is used, just made larger than default) and adding icons to the task filter bar at the bottom of the main page.

Once the backend is set up, the checkboxes will have to be modified so that, when clicked, they send the task to the next stage. It is also my goal to allow the user to click on the task to access the task edit page once the backend is set up.