### PR TITLE
Add linting configurations for frontend and backend

### DIFF
--- a/back-end/.eslintrc.json
+++ b/back-end/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": [
+        "airbnb"
+    ],
+    "overrides": [
+    ],
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "plugins": [
+    ],
+    "rules": {
+        "semi": [2, "never"],
+        "indent": [2, 4],
+        "no-unused-vars": 0,
+        "arrow-parens": [2, "as-needed"],
+        "object-curly-newline": 0
+    }
+}

--- a/back-end/.eslintrc.json
+++ b/back-end/.eslintrc.json
@@ -1,7 +1,8 @@
 {
     "env": {
         "browser": true,
-        "es2021": true
+        "es2021": true,
+        "es6": true
     },
     "extends": [
         "airbnb"
@@ -18,7 +19,11 @@
         "semi": [2, "never"],
         "indent": [2, 4],
         "no-unused-vars": 0,
+        "no-console": 0,
         "arrow-parens": [2, "as-needed"],
         "object-curly-newline": 0
+    },
+    "globals": {
+        "__dirname": true
     }
 }

--- a/back-end/.gitignore
+++ b/back-end/.gitignore
@@ -1,0 +1,25 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+package-lock.json

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -1,8 +1,9 @@
-const express = require("express")
+import express from 'express'
+
 const app = express()
 
-app.get("/", (req, res) => {
-    res.send("Hello!")
+app.get('/', (req, res) => {
+    res.send('Hello!')
 })
 
-module.exports = app
+export default app

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -10,5 +10,13 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "eslint": "^8.37.0",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0"
   }
 }

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -1,19 +1,16 @@
 #!/usr/bin/env node
-
-const server = require("./app") // load up the web server
+import app from './app'
 
 const port = 3000 // the port to listen to for incoming requests
 
 // call express's listen function to start listening to the port
-const listener = server.listen(port, function () {
-  console.log(`Server running on port: ${port}`)
+const listener = app.listen(port, () => {
+    console.log(`Server running on port: ${port}`)
 })
 
 // a function to stop listening to the port
 const close = () => {
-  listener.close()
+    listener.close()
 }
 
-module.exports = {
-  close: close,
-}
+export default close

--- a/front-end/.eslintrc.json
+++ b/front-end/.eslintrc.json
@@ -23,11 +23,12 @@
         "no-unused-vars": 0,
         "arrow-parens": [2, "as-needed"],
         "object-curly-newline": 0,
+        "jsx-a11y/label-has-associated-control": 0,
         "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx"] }],
         "react/function-component-definition": [2, {
             "namedComponents": "arrow-function",
             "unnamedComponents": "arrow-function"
         }],
-        "react/no-array-index-key": 1
+        "react/no-array-index-key": 0
     }
 }

--- a/front-end/.eslintrc.json
+++ b/front-end/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": [
+        "react-app",
+        "airbnb"
+    ],
+    "overrides": [
+    ],
+    "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "plugins": [
+        "react"
+    ],
+    "rules": {
+        "semi": [2, "never"],
+        "indent": [2, 4],
+        "react/jsx-indent": [2, 4],
+        "no-unused-vars": 0,
+        "arrow-parens": [2, "as-needed"],
+        "object-curly-newline": 0,
+        "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx"] }],
+        "react/function-component-definition": [2, {
+            "namedComponents": "arrow-function",
+            "unnamedComponents": "arrow-function"
+        }],
+        "react/no-array-index-key": 1
+    }
+}

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -36,5 +36,13 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "eslint": "^8.37.0",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0"
   }
 }


### PR DESCRIPTION
This PR adds linting to both the frontend and the backend for consistency in code style.

All developers should (1) `npm install` on both the frontend and backend to install the new linting dependencies, and (2) install the ESLint extension in VSCode so that linting issues are visible in the IDE.