### PR TITLE
Add changes to linting configuration

### DIFF
--- a/back-end/.eslintrc.json
+++ b/back-end/.eslintrc.json
@@ -21,7 +21,9 @@
         "no-unused-vars": 0,
         "no-console": 0,
         "arrow-parens": [2, "as-needed"],
-        "object-curly-newline": 0
+        "object-curly-newline": 0,
+        "comma-dangle": [2, "never"],
+        "prefer-destructuring": 0
     },
     "globals": {
         "__dirname": true

--- a/back-end/.eslintrc.json
+++ b/back-end/.eslintrc.json
@@ -23,7 +23,8 @@
         "arrow-parens": [2, "as-needed"],
         "object-curly-newline": 0,
         "comma-dangle": [2, "never"],
-        "prefer-destructuring": 0
+        "prefer-destructuring": 0,
+        "no-param-reassign": [2, { "req": false, "res": false }]
     },
     "globals": {
         "__dirname": true

--- a/front-end/.eslintrc.json
+++ b/front-end/.eslintrc.json
@@ -26,6 +26,7 @@
         "object-curly-newline": 0,
         "comma-dangle": [2, "never"],
         "prefer-destructuring": 0,
+        "no-param-reassign": [2, { "props": false }],
         "jsx-a11y/label-has-associated-control": 0,
         "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx"] }],
         "react/function-component-definition": [2, {

--- a/front-end/.eslintrc.json
+++ b/front-end/.eslintrc.json
@@ -22,6 +22,7 @@
         "react/jsx-indent-props": [2, 4],
         "react/jsx-indent": [2, 4],
         "no-unused-vars": 0,
+        "no-console": 0,
         "arrow-parens": [2, "as-needed"],
         "object-curly-newline": 0,
         "comma-dangle": [2, "never"],

--- a/front-end/.eslintrc.json
+++ b/front-end/.eslintrc.json
@@ -19,16 +19,21 @@
     "rules": {
         "semi": [2, "never"],
         "indent": [2, 4],
+        "react/jsx-indent-props": [2, 4],
         "react/jsx-indent": [2, 4],
         "no-unused-vars": 0,
         "arrow-parens": [2, "as-needed"],
         "object-curly-newline": 0,
+        "comma-dangle": [2, "never"],
+        "prefer-destructuring": 0,
         "jsx-a11y/label-has-associated-control": 0,
         "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx"] }],
         "react/function-component-definition": [2, {
             "namedComponents": "arrow-function",
             "unnamedComponents": "arrow-function"
         }],
-        "react/no-array-index-key": 0
+        "react/no-array-index-key": 0,
+        "react/destructuring-assignment": [2, "never"],
+        "react/prop-types": 0
     }
 }


### PR DESCRIPTION
While completing my linting work, I found some issues with the current linting configuration. The new linting configuration:

- Fixes destructuring issues (one rule did not allow it, one rule required it, creating a conflict. Now it is not permitted across the board)
- Does not allow trailing commas in list (previously were required)
- Removes two arbitrary react requirements that aren't quite in the scope of this class (not allowing keys to be indexes, forcing prop types to be declared explicitly)