### PR TITLE
Turn header title into link

### DIFF
--- a/front-end/src/Header.css
+++ b/front-end/src/Header.css
@@ -46,3 +46,8 @@ Link.headerElement {
 #mk-task-link:hover{
     text-decoration: none;
 }
+
+#main-title{
+    color: #2b4660;
+    text-decoration: none;
+}

--- a/front-end/src/Header.js
+++ b/front-end/src/Header.js
@@ -11,7 +11,9 @@ import Sidebar from './Sidebar'
 const Header = props => (
     <header className="Header-header">
         <Sidebar className="headerElement" pageWrapId="page-wrap" outerContainerId="outer-container" />
-        <h1 className="headerElement">FinishIt</h1>
+        <h1 className="headerElement">
+            <Link to="/" className="headerElement" id="main-title">FinishIt</Link>
+        </h1>
         <Link to="/newtask" className="headerElement" id="mk-task-link">
             <button id="mk-task" type="button">+</button>
         </Link>


### PR DESCRIPTION
You can now click on the **FinishIt** title on the header to return to the root URI.